### PR TITLE
rewrite osclient creation, supports specified api microversion

### DIFF
--- a/openapi_server/denbi/__init__.py
+++ b/openapi_server/denbi/__init__.py
@@ -2,36 +2,22 @@
 import os
 
 import openstack
-from keystoneauth1 import session
-from keystoneauth1.identity import v3
+import os_client_config
 
-
-def create_session(app_name="denbi", app_version="1.0"):
-    """
-    Create a keystone session
-
-    :param app_name:
-    :param app_version:
-    :return: Return a openstack session object.
-    """
-    auth = v3.Password(username=os.environ["OS_USERNAME"],
-                       password=os.environ["OS_PASSWORD"],
-                       auth_url=os.environ["OS_AUTH_URL"],
-                       project_name=os.environ["OS_PROJECT_NAME"],
-                       user_domain_name=os.environ["OS_USER_DOMAIN_NAME"],
-                       project_domain_name=os.environ["OS_USER_DOMAIN_NAME"])
-    return session.Session(auth=auth, app_name=app_name, app_version=app_version)
-
-
-def create_osclient(session=None): # pylint: disable=W0621
+def create_osclient(microversions={'compute':'2.79'}): # pylint: disable=W0621
     """
     Create an authorized openstack.connection.Connection object, that allows
     REST API calls.
 
-    :param session: Optional, if not set create_session is called
+    :param: microversions - a dict containing microversions, where the key
+    describes the service and the value the microversion to be used
+
     :return: Return an authorized openstack.connection.Connection object
     """
 
-    if not session:
-        session = create_session()
-    return openstack.connection.Connection(session=session)
+    config=os_client_config.get_config()
+
+    for service in microversions:
+        config.config[f'{service}_default_microversion']=microversions[service]
+
+    return openstack.connection.Connection(config=config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.1.1
 openstacksdk
+os_client_config
 gunicorn
 pymemcache


### PR DESCRIPTION
Adjustments to support microversions and default compute microversion to 2.79 (Train release).