### PR TITLE
Strip domain from hostname in hypervisors list

### DIFF
--- a/openapi_server/denbi/resources.py
+++ b/openapi_server/denbi/resources.py
@@ -45,7 +45,7 @@ class GPUResources: # pylint: disable=too-many-instance-attributes
                     for instance in self.__gpu_instances_by_host__[hostname]:
                         used = used + int(instance["flavor"]["extra_specs"]["pci_passthrough:alias"].split(":")[1])
 
-                hypervisor = self.__hypervisors__[hostname]
+                hypervisor = self.__hypervisors__[hostname.split('.')[0]]
 
                 gpu_hypervisors.append({"name": hypervisor["name"].split('.')[0],
                                         "status": hypervisor["status"],


### PR DESCRIPTION
Our OpenStack installation has some minor difference from the trunk repo instllation that prevents OpenstackGPUService ftom running in our environment.

Namely, it seems that list of hosts in the aggregate in "openstack aggregate show" can be returned with or without ".localdomain'" appended in different OpenStack versions. Since hosts in the "openstack hypervisor list" are returned with ".localdomain", it prevents OpenstackGPUService from starting due to Python key error.

In order to fix that, I propose a fix that will strip ".localdomain" from the list of hosts in the aggregate as well as from the list of hosts in the hypervisors list.