### PR TITLE
Explicit Alpine version set in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-alpine3.20
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Docker image won't build with the latest version of Alpine due to library versions incompatibility. 3.20 is the laterst version I was able to build it successfully.